### PR TITLE
feat/chore: Update JSON schema, minor adjustments

### DIFF
--- a/config.go
+++ b/config.go
@@ -43,6 +43,7 @@ func (c *Config) InitDefaults() {
 	if c.Pool == nil {
 		c.Pool = &poolImpl.Config{}
 	}
+	c.Pool.InitDefaults()
 
 	if c.CfgOptions == nil {
 		c.CfgOptions = &CfgOptions{
@@ -67,8 +68,6 @@ func (c *Config) InitDefaults() {
 	if c.Timeout == 0 {
 		c.Timeout = 60
 	}
-
-	c.Pool.InitDefaults()
 
 	// number of pollers should be slightly more than the number of workers
 	// overwrite user value, TODO: deprecate this configuration option

--- a/schema.json
+++ b/schema.json
@@ -7,13 +7,14 @@
   "additionalProperties": false,
   "properties": {
     "num_pollers": {
-      "description": "Number of threads which will try to obtain jobs from the priority queue. Default is the number of workers in the pool +1.",
+      "description": "Number of threads which will try to obtain jobs from the priority queue. Default is the number of workers in the pool +1. **Deprecated:** This will be removed in a future version.",
       "type": "integer",
       "minimum": 1,
       "examples": [
         10,
         32
-      ]
+      ],
+      "deprecated": true
     },
     "timeout": {
       "description": "Request timeout (in seconds) when attempting to send jobs to the queue. If zero or omitted, this defaults to 60 seconds.",
@@ -21,13 +22,13 @@
       "default": 60
     },
     "pipeline_size": {
-      "description": "Size of the internal priority queue. If the internal priority queue is full, you cannot send (push) additional jobs to the queue. If you set this value to zero, it defaults to 1 million.",
+      "description": "Size of the internal priority queue. If the internal priority queue is full, you cannot send (push) additional jobs to the queue. If you set this value to zero or omit it, it defaults to 1 million.",
       "type": "integer",
       "default": 1000000,
       "minimum": 0
     },
     "consume": {
-      "description": "A list of pipelines to be consumed by the server automatically when starting. You can omit this list if you want to start consuming manually. Each key in this list must be defined under `pipelines`.",
+      "description": "A list of pipelines to be consumed by the server automatically when starting. You can omit this list if you want to start consuming manually. Each item in this list must be defined as a key under `pipelines`.",
       "type": "array",
       "items": {
         "type": "string",
@@ -35,8 +36,7 @@
       }
     },
     "pool": {
-      "description": "Worker pool configuration for jobs.",
-      "$ref": "https://raw.githubusercontent.com/roadrunner-server/roadrunner/refs/heads/master/schemas/config/3.0.schema.json#/definitions/WorkersPool"
+      "$ref": "https://raw.githubusercontent.com/roadrunner-server/pool/refs/heads/master/schema.json"
     },
     "pipelines": {
       "description": "List of broker pipelines associated with the configured drivers. This option is not required since you can declare pipelines at runtime. The selected pipeline `driver` must be configured in the root of your configuration file.",


### PR DESCRIPTION
Move init default call to more reasonable place for pool Deprecate num_pollers in schema

# Reason for This PR

The pool property was moved from the main repo to its own, where it belongs. This reference needs update.

## Description of Changes

Updated pool to reference its repo.
Deprecated num_pollers in schema.
Moved InitDefaults up closer to where it's used.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced clarity in the JSON schema for the RoadRunner jobs plugin, including updated descriptions for various properties.
  
- **Deprecations**
	- Added a deprecation notice for the `num_pollers` property, indicating future removal.

- **Improvements**
	- Updated default behavior descriptions for `pipeline_size` and `consume` properties to improve user understanding.
	- Changed the reference for the `pool` property to a new schema URL for better configuration management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->