### PR TITLE
chore: Remove legacy consume_all feature

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -85,11 +85,6 @@
         "type": "integer",
         "minimum": 0
       },
-      "consume_all": {
-        "description": "Normally only jobs with a Jobs structure are consumed. Enable this to consume all jobs on the queue.",
-        "type": "boolean",
-        "default": false
-      },
       "queue": {
         "type": "string",
         "description": "The name of the queue.",


### PR DESCRIPTION
# Reason for This PR

The property `consume_all` was removed and no longer serves any purpose.

Note that this PR must be merged last of all the PRs that remove this property, or schema validation tests in the main repo will fail:

https://github.com/roadrunner-server/amqp/pull/167
https://github.com/roadrunner-server/beanstalk/pull/144
https://github.com/roadrunner-server/nats/pull/176
https://github.com/roadrunner-server/sqs/pull/573

## Description of Changes

Removed `consume_all`.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [ ] All commits in this PR are signed (`git commit -s`).
- [ ] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [ ] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
