### PR TITLE
Add poller graceful shutdown

### DIFF
--- a/config.go
+++ b/config.go
@@ -32,6 +32,8 @@ type Config struct {
 	Pipelines map[string]Pipeline `mapstructure:"pipelines"`
 	// Consuming specifies names of pipelines to be consumed on service start.
 	Consume []string `mapstructure:"consume"`
+	// PollersGracefulShutdown is the flag for wait current tasks done in each poller
+	PollersGracefulShutdown bool `mapstructure:"pollers_graceful_shutdown"`
 }
 
 type CfgOptions struct {

--- a/listener.go
+++ b/listener.go
@@ -15,6 +15,11 @@ import (
 func (p *Plugin) listener() {
 	for i := 0; i < p.cfg.NumPollers; i++ {
 		go func() {
+			if p.cfg.PollersGracefulShutdown {
+				p.pollersWg.Add(1)
+				p.log.Debug("poller added to wait group", zap.Int("poller", i))
+				defer p.pollersWg.Done()
+			}
 			for {
 				select {
 				case <-p.stopCh:

--- a/schema.json
+++ b/schema.json
@@ -69,6 +69,11 @@
           ]
         }
       }
+    },
+    "pollers_graceful_shutdown": {
+      "description": "Wait all pollers for handle current tasks.",
+      "type": "boolean",
+      "default": false
     }
   },
   "definitions": {


### PR DESCRIPTION
# Reason for This PR

When terminate roadrunner process we have some pollers errors like this:
```
response handler error  {"error": "jobs_handle_response: failed to acknowledge the JOB, the pipeline is probably stopped", ...}
```

Because of this errors we have incorrect logic to exit from handled(or not) job, consumers die too early, worker can't send acknowledgement of the job.

If this behavior can be fixed by exist settings or something like that, please say how we can escape from this error

## Description of Changes

- added wait group for pollers
- added to config `pollers_graceful_shutdown` for wait until all pollers are done 

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the MIT license.

## PR Checklist

`[Author TODO: Meet these criteria.]`
`[Reviewer TODO: Verify that these criteria are met. Request changes if not]`

- [x] All commits in this PR are signed (`git commit -s`).
- [x] The reason for this PR is clearly provided (issue no. or explanation).
- [ ] The description of changes is clear and encompassing.
- [ ] Any required documentation changes (code and docs) are included in this PR.
- [x] Any user-facing changes are mentioned in `CHANGELOG.md`.
- [ ] All added/changed functionality is tested.
