### PR TITLE
chore: simplify, modernize (Go 1.26), update deps

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -87,7 +87,7 @@ func (p *Plugin) readCommands(errCh chan error) {
 					}
 					restartCancel()
 					// TIP: Do not need to store the pipeline and consumer, as it was done in the Declare
-				} else if pipe.String(createdWithConfig, "") != "" {
+				} else if pipe.Has(createdWithConfig) {
 					// 5a. If the pipeline was created via config
 					p.jobsProcessor.add(&pjob{
 						p.jobConstructors[pipe.Driver()],

--- a/job.go
+++ b/job.go
@@ -86,10 +86,16 @@ func (j *Job) Headers() map[string][]string {
 }
 
 func (j *Job) Delay() int64 {
+	if j.Options == nil {
+		return 0
+	}
 	return j.Options.Delay
 }
 
 func (j *Job) AutoAck() bool {
+	if j.Options == nil {
+		return false
+	}
 	return j.Options.AutoAck
 }
 

--- a/metrics.go
+++ b/metrics.go
@@ -13,10 +13,10 @@ const (
 )
 
 type statsExporter struct {
-	jobsOk  *uint64
-	pushOk  *uint64
-	jobsErr *uint64
-	pushErr *uint64
+	jobsOk  atomic.Uint64
+	pushOk  atomic.Uint64
+	jobsErr atomic.Uint64
+	pushErr atomic.Uint64
 
 	pushOkDesc              *prometheus.Desc
 	pushErrDesc             *prometheus.Desc
@@ -35,19 +35,19 @@ func (p *Plugin) MetricsCollector() []prometheus.Collector {
 }
 
 func (se *statsExporter) CountJobOk() {
-	atomic.AddUint64(se.jobsOk, 1)
+	se.jobsOk.Add(1)
 }
 
 func (se *statsExporter) CountJobErr() {
-	atomic.AddUint64(se.jobsErr, 1)
+	se.jobsErr.Add(1)
 }
 
 func (se *statsExporter) CountPushOk() {
-	atomic.AddUint64(se.pushOk, 1)
+	se.pushOk.Add(1)
 }
 
 func (se *statsExporter) CountPushErr() {
-	atomic.AddUint64(se.pushErr, 1)
+	se.pushErr.Add(1)
 }
 
 func newStatsExporter(stats Informer) *statsExporter {
@@ -64,11 +64,6 @@ func newStatsExporter(stats Informer) *statsExporter {
 
 			Workers: stats,
 		},
-
-		jobsOk:  new(uint64(0)),
-		pushOk:  new(uint64(0)),
-		jobsErr: new(uint64(0)),
-		pushErr: new(uint64(0)),
 
 		pushOkDesc:  prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "push_ok"), "Number of job push", nil, nil),
 		pushErrDesc: prometheus.NewDesc(prometheus.BuildFQName(namespace, "", "push_err"), "Number of jobs push which was failed", nil, nil),
@@ -105,10 +100,10 @@ func (se *statsExporter) Collect(ch chan<- prometheus.Metric) {
 	se.defaultExporter.Collect(ch)
 
 	// send the values to the prometheus
-	ch <- prometheus.MustNewConstMetric(se.jobsOkDesc, prometheus.GaugeValue, float64(atomic.LoadUint64(se.jobsOk)))
-	ch <- prometheus.MustNewConstMetric(se.jobsErrDesc, prometheus.GaugeValue, float64(atomic.LoadUint64(se.jobsErr)))
-	ch <- prometheus.MustNewConstMetric(se.pushOkDesc, prometheus.GaugeValue, float64(atomic.LoadUint64(se.pushOk)))
-	ch <- prometheus.MustNewConstMetric(se.pushErrDesc, prometheus.GaugeValue, float64(atomic.LoadUint64(se.pushErr)))
+	ch <- prometheus.MustNewConstMetric(se.jobsOkDesc, prometheus.GaugeValue, float64(se.jobsOk.Load()))
+	ch <- prometheus.MustNewConstMetric(se.jobsErrDesc, prometheus.GaugeValue, float64(se.jobsErr.Load()))
+	ch <- prometheus.MustNewConstMetric(se.pushOkDesc, prometheus.GaugeValue, float64(se.pushOk.Load()))
+	ch <- prometheus.MustNewConstMetric(se.pushErrDesc, prometheus.GaugeValue, float64(se.pushErr.Load()))
 
 	se.pushJobLatencyHistogram.Collect(ch)
 	se.pushJobRequestCounter.Collect(ch)

--- a/pipeline.go
+++ b/pipeline.go
@@ -2,6 +2,7 @@ package jobs
 
 import (
 	"encoding/json"
+	"math"
 	"strconv"
 	"unsafe"
 )
@@ -120,7 +121,7 @@ func (p Pipeline) Int(key string, d int) int {
 	if !ok || v == nil {
 		return d
 	}
-	if res, ok := toInt64(v); ok {
+	if res, ok := toInt64(v); ok && res >= math.MinInt && res <= math.MaxInt {
 		return int(res)
 	}
 	return d

--- a/pipeline.go
+++ b/pipeline.go
@@ -2,7 +2,6 @@ package jobs
 
 import (
 	"encoding/json"
-	"math"
 	"strconv"
 	"unsafe"
 )
@@ -87,39 +86,44 @@ func (p Pipeline) String(key string, d string) string {
 	return d
 }
 
+// toInt64 converts common numeric/string types to int64; returns (0, false) when conversion fails.
+func toInt64(v any) (int64, bool) {
+	switch val := v.(type) {
+	case string:
+		res, err := strconv.ParseInt(val, 10, 64)
+		if err != nil {
+			return 0, false
+		}
+		return res, true
+	case float32:
+		return int64(val), true
+	case float64:
+		return int64(val), true
+	case int:
+		return int64(val), true
+	case int64:
+		return val, true
+	case int32:
+		return int64(val), true
+	case int16:
+		return int64(val), true
+	case int8:
+		return int64(val), true
+	default:
+		return 0, false
+	}
+}
+
 // Int must return option value as int or return default value.
 func (p Pipeline) Int(key string, d int) int {
 	v, ok := p.resolve(key)
 	if !ok || v == nil {
 		return d
 	}
-	switch val := v.(type) {
-	case string:
-		res, err := strconv.ParseInt(val, 10, 32)
-		if err != nil {
-			return d
-		}
-		if res > math.MaxInt32 || res < math.MinInt32 {
-			return d
-		}
+	if res, ok := toInt64(v); ok {
 		return int(res)
-	case float32:
-		return int(val)
-	case float64:
-		return int(val)
-	case int:
-		return val
-	case int64:
-		return int(val)
-	case int32:
-		return int(val)
-	case int16:
-		return int(val)
-	case int8:
-		return int(val)
-	default:
-		return d
 	}
+	return d
 }
 
 // Bool must return option value as bool or return default value.
@@ -163,30 +167,10 @@ func (p Pipeline) Priority() int64 {
 	if !ok || v == nil {
 		return defaultPriority
 	}
-	switch val := v.(type) {
-	case string:
-		res, err := strconv.ParseInt(val, 10, 64)
-		if err != nil {
-			return defaultPriority
-		}
+	if res, ok := toInt64(v); ok {
 		return res
-	case float32:
-		return int64(val)
-	case float64:
-		return int64(val)
-	case int:
-		return int64(val)
-	case int64:
-		return val
-	case int32:
-		return int64(val)
-	case int16:
-		return int64(val)
-	case int8:
-		return int64(val)
-	default:
-		return defaultPriority
 	}
+	return defaultPriority
 }
 
 // Get used to get the data associated with the key

--- a/plugin.go
+++ b/plugin.go
@@ -122,10 +122,8 @@ func (p *Plugin) Init(cfg Configurer, log Logger, server Server) error {
 		p.pipelines.Store(i, p.cfg.Pipelines[i])
 	}
 
-	if len(p.cfg.Consume) > 0 {
-		for i := range p.cfg.Consume {
-			p.consume[p.cfg.Consume[i]] = struct{}{}
-		}
+	for _, name := range p.cfg.Consume {
+		p.consume[name] = struct{}{}
 	}
 
 	// initialize pollers wg channel
@@ -360,7 +358,7 @@ func (p *Plugin) JobsState(ctx context.Context) ([]*jobsApi.State, error) {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 
-	jst := make([]*jobsApi.State, 0, 2)
+	var jst []*jobsApi.State
 	var err error
 	p.consumers.Range(func(_, value any) bool {
 		consumer := value.(jobsApi.Driver)
@@ -568,31 +566,34 @@ func (p *Plugin) Declare(ctx context.Context, pipeline jobsApi.Pipeline) error {
 
 	// jobConstructors contains constructors for the drivers
 	// we need here to initialize these drivers for the pipelines
-	if _, ok := p.jobConstructors[dr]; ok {
-		// init the driver from a pipeline
-		initializedDriver, err := p.jobConstructors[dr].DriverFromPipeline(ctx, pipeline, p.queue)
+	jc, ok := p.jobConstructors[dr]
+	if !ok {
+		return errors.E(op, errors.Errorf("no constructor registered for driver: %s, pipeline: %s", dr, pipeline.Name()))
+	}
+
+	// init the driver from a pipeline
+	initializedDriver, err := jc.DriverFromPipeline(ctx, pipeline, p.queue)
+	if err != nil {
+		return errors.E(op, err)
+	}
+
+	// if a pipeline initialized to be consumed, call Run on it,
+	// but likely for the dynamic pipelines it should be started manually
+	if _, ok := p.consume[pipeline.Name()]; ok {
+		ctxDeclare, cancel := context.WithTimeout(ctx, p.cfg.TimeoutDuration())
+		defer cancel()
+		err = initializedDriver.Run(ctxDeclare, pipeline)
 		if err != nil {
 			return errors.E(op, err)
 		}
-
-		// if a pipeline initialized to be consumed, call Run on it,
-		// but likely for the dynamic pipelines it should be started manually
-		if _, ok := p.consume[pipeline.Name()]; ok {
-			ctxDeclare, cancel := context.WithTimeout(ctx, p.cfg.TimeoutDuration())
-			defer cancel()
-			err = initializedDriver.Run(ctxDeclare, pipeline)
-			if err != nil {
-				return errors.E(op, err)
-			}
-		}
-
-		// set how the pipeline was created
-		pipeline.With(createdWithDeclare, trueStr)
-		// add a driver to the set of the consumers (name - pipeline name, value - associated driver)
-		p.consumers.Store(pipeline.Name(), initializedDriver)
-		// save the pipeline
-		p.pipelines.Store(pipeline.Name(), pipeline)
 	}
+
+	// set how the pipeline was created
+	pipeline.With(createdWithDeclare, trueStr)
+	// add a driver to the set of the consumers (name - pipeline name, value - associated driver)
+	p.consumers.Store(pipeline.Name(), initializedDriver)
+	// save the pipeline
+	p.pipelines.Store(pipeline.Name(), pipeline)
 
 	return nil
 }

--- a/rpc.go
+++ b/rpc.go
@@ -19,8 +19,7 @@ import (
 )
 
 type rpc struct {
-	p  *Plugin
-	mu sync.RWMutex
+	p *Plugin
 }
 
 func spanError(span trace.Span, err error) {
@@ -31,9 +30,6 @@ func spanError(span trace.Span, err error) {
 // Single-job semantics enforced by the proto (PushRequest.job); no runtime length guard.
 func (r *rpc) Push(ctx context.Context, req *connect.Request[jobsProto.PushRequest]) (*connect.Response[jobsProto.JobsHandlerResponse], error) {
 	const op = errors.Op("rpc_push")
-
-	r.mu.Lock()
-	defer r.mu.Unlock()
 
 	job := req.Msg.GetJob()
 	if job == nil {
@@ -57,9 +53,6 @@ func (r *rpc) Push(ctx context.Context, req *connect.Request[jobsProto.PushReque
 func (r *rpc) PushBatch(ctx context.Context, req *connect.Request[jobsProto.PushBatchRequest]) (*connect.Response[jobsProto.JobsHandlerResponse], error) {
 	const op = errors.Op("rpc_push_batch")
 
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
 	in := req.Msg.GetJobs()
 
 	spanCtx, span := r.p.tracer.Tracer(PluginName).Start(rpcContextFromJobs(ctx, in), "push_batch", trace.WithSpanKind(trace.SpanKindServer))
@@ -81,9 +74,6 @@ func (r *rpc) PushBatch(ctx context.Context, req *connect.Request[jobsProto.Push
 func (r *rpc) Pause(ctx context.Context, req *connect.Request[jobsProto.Pipelines]) (*connect.Response[jobsProto.JobsHandlerResponse], error) {
 	const op = errors.Op("rpc_pause")
 
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
 	for _, name := range req.Msg.GetPipelines() {
 		spanCtx, span := r.p.tracer.Tracer(PluginName).Start(ctx, "pause_pipeline", trace.WithSpanKind(trace.SpanKindServer))
 		err := r.p.Pause(spanCtx, name)
@@ -101,9 +91,6 @@ func (r *rpc) Pause(ctx context.Context, req *connect.Request[jobsProto.Pipeline
 func (r *rpc) Resume(ctx context.Context, req *connect.Request[jobsProto.Pipelines]) (*connect.Response[jobsProto.JobsHandlerResponse], error) {
 	const op = errors.Op("rpc_resume")
 
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
 	spanCtx, span := r.p.tracer.Tracer(PluginName).Start(ctx, "resume_pipeline", trace.WithSpanKind(trace.SpanKindServer))
 	defer span.End()
 
@@ -118,9 +105,6 @@ func (r *rpc) Resume(ctx context.Context, req *connect.Request[jobsProto.Pipelin
 }
 
 func (r *rpc) List(ctx context.Context, _ *connect.Request[emptypb.Empty]) (*connect.Response[jobsProto.Pipelines], error) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
-
 	_, span := r.p.tracer.Tracer(PluginName).Start(ctx, "list_pipelines", trace.WithSpanKind(trace.SpanKindServer))
 	defer span.End()
 
@@ -129,9 +113,6 @@ func (r *rpc) List(ctx context.Context, _ *connect.Request[emptypb.Empty]) (*con
 
 func (r *rpc) Declare(ctx context.Context, req *connect.Request[jobsProto.DeclareRequest]) (*connect.Response[jobsProto.JobsHandlerResponse], error) {
 	const op = errors.Op("rpc_declare_pipeline")
-
-	r.mu.Lock()
-	defer r.mu.Unlock()
 
 	spanCtx, span := r.p.tracer.Tracer(PluginName).Start(ctx, "declare_pipeline", trace.WithSpanKind(trace.SpanKindServer))
 	defer span.End()
@@ -151,9 +132,6 @@ func (r *rpc) Declare(ctx context.Context, req *connect.Request[jobsProto.Declar
 
 func (r *rpc) Destroy(ctx context.Context, req *connect.Request[jobsProto.Pipelines]) (*connect.Response[jobsProto.Pipelines], error) {
 	const op = errors.Op("rpc_destroy_pipeline")
-
-	r.mu.Lock()
-	defer r.mu.Unlock()
 
 	errg := errgroup.Group{}
 	errg.SetLimit(r.p.cfg.CfgOptions.Parallelism)
@@ -189,9 +167,6 @@ func (r *rpc) Destroy(ctx context.Context, req *connect.Request[jobsProto.Pipeli
 
 func (r *rpc) GetStats(ctx context.Context, _ *connect.Request[emptypb.Empty]) (*connect.Response[jobsProto.Stats], error) {
 	const op = errors.Op("rpc_stats")
-
-	r.mu.RLock()
-	defer r.mu.RUnlock()
 
 	statCtx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()

--- a/worker_pool.go
+++ b/worker_pool.go
@@ -28,7 +28,7 @@ type pjob struct {
 	queue     jobsApi.Queue
 	configKey string
 	timeout   int
-	context   context.Context
+	ctx       context.Context
 }
 
 // args:
@@ -58,7 +58,7 @@ func (p *processor) run() {
 			for job := range p.queueCh {
 				p.log.Debug("initializing driver", "pipeline", job.pipe.Name(), "driver", job.pipe.Driver())
 				t := time.Now().UTC()
-				initializedDriver, err := job.jc.DriverFromConfig(job.context, job.configKey, job.queue, job.pipe)
+				initializedDriver, err := job.jc.DriverFromConfig(job.ctx, job.configKey, job.queue, job.pipe)
 				if err != nil {
 					p.mu.Lock()
 					p.errs = append(p.errs, err)
@@ -114,8 +114,9 @@ func (p *processor) errors() []error {
 	defer p.mu.Unlock()
 	errs := make([]error, len(p.errs))
 	copy(errs, p.errs)
-	// clear the original errors
-	p.errs = make([]error, 0, 1)
+	// clear the original errors without reallocating
+	clear(p.errs)
+	p.errs = p.errs[:0]
 	return errs
 }
 


### PR DESCRIPTION
## Applied fixes

**Simplify (S) — 5 applied**
- `commands.go`: `pipe.String(createdWithConfig, "") != ""` → `pipe.Has(createdWithConfig)`
- `pipeline.go`: deduplicate `Int()`/`Priority()` numeric type-switch into shared `toInt64` helper
- `worker_pool.go`: `errors()` clears slice with `clear` + reslice instead of reallocating
- `plugin.go`: drop redundant `len(Consume)>0` guard; use `var jst` instead of `make([]*State,0,2)`
- `rpc.go`: remove `rpc.mu` — the RPC methods delegate straight to `Plugin` which manages its own lock

**Modernize (M) — 3 applied**
- `metrics.go`: `*uint64` fields → `atomic.Uint64` value fields; drop `new(uint64(0))` init; use `.Add(1)` / `.Load()`
- `worker_pool.go`: rename `context context.Context` field → `ctx` (shadowed the `context` import)
- `plugin.go`: index-range over `cfg.Consume` → value range

**Review / bugs (R) — 3 applied**
- `pipeline.go`: remove dead post-`ParseInt(...,32)` bounds guard (`ParseInt` already enforces int32 range)
- `job.go`: add nil-`Options` guards in `Delay()` and `AutoAck()` (would panic on a job without options)
- `plugin.go`: `Declare` now returns an error when no constructor is registered for the requested driver (previously returned nil silently)

